### PR TITLE
new version fix minor errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto_relocating"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/adapters/progress_bar_adapter.rs
+++ b/src/adapters/progress_bar_adapter.rs
@@ -41,7 +41,7 @@ impl ProgressBarAdapter {
             "{} Directory {}: {}",
             style("[ERROR]").red().bold(),
             style(directory).bold(),
-            error
+            error.escape_default()
         ));
     }
 

--- a/src/controllers/params.rs
+++ b/src/controllers/params.rs
@@ -1,4 +1,4 @@
-use std::{fmt, fs};
+use std::fs;
 
 use super::path_items::PathItems;
 use serde;
@@ -17,16 +17,6 @@ impl Default for RelocateParams {
             folder_read: String::new(),
             deep_search: false,
         }
-    }
-}
-
-impl fmt::Display for RelocateParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "--path \"{}\" --from \"{}\" --to \"{}\" --deep \"{}\"",
-            self.folder_read, self.path_items[0], self.path_items[1], self.deep_search
-        )
     }
 }
 

--- a/src/controllers/relocate_controller.rs
+++ b/src/controllers/relocate_controller.rs
@@ -27,10 +27,14 @@ impl RelocateController {
     }
 
     pub fn run(&self) {
-        self.directories
+        let threads: Vec<JoinHandle<()>> = self
+            .directories
             .clone()
             .into_iter()
             .map(|directory| self.create_relocate_thread(&directory))
+            .collect();
+        threads
+            .into_iter()
             .for_each(|thread| thread.join().unwrap())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod adapters;
 pub mod controllers;
 
+use std::process::Command;
+
 use controllers::params_reader::arg_reader;
 use controllers::params_writer;
 use controllers::path_items::PathItems;
@@ -14,9 +16,21 @@ pub fn configure() {
 
 pub fn export() {
     let params = file_reader::get_from_file().expect("You don't have data to be exported");
-    let params_str = params.to_string();
 
-    print!("{} {} {}", "auto_relocating", "import", params_str);
+    let mut command = Command::new("auto_relocating");
+    command.args([
+        "import",
+        "--path",
+        params.folder_read.as_str(),
+        "--from",
+        params.path_items[0].as_str(),
+        "--to",
+        params.path_items[1].as_str(),
+        "--deep",
+        params.deep_search.to_string().as_str(),
+    ]);
+
+    print!("{:?}", command);
 }
 
 pub fn import(args: &Vec<String>) -> PathItems {


### PR DESCRIPTION
Relocating now works multi thread
Error messages taking just one line
Exporting "C:\" path work as intended